### PR TITLE
net/cifs-utils: missing dependency

### DIFF
--- a/net/cifs-utils/Makefile
+++ b/net/cifs-utils/Makefile
@@ -24,6 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/cifsmount
   SECTION:=net
   CATEGORY:=Network
+  DEPENDS:=+kmod-fs-cifs
   TITLE:=CIFS mount utilities
   URL:=http://wiki.samba.org/index.php/LinuxCIFS_utils
 endef


### PR DESCRIPTION
'cifsmount' alone is not able to mount a SMB share, after
having installed kmod-fs-cifs this was possible.
So I guess adding kmod-fs-cifs as a dependency to cifsmount is ok.

Signed-off-by: Paul Wassi <p.wassi@gmx.at>